### PR TITLE
Fix Gemfile.lock for cross-platform builds (Linux CI + Windows dev)

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
     webrick (1.9.1)
+    wdm (0.2.0)
 
 PLATFORMS
   x64-mingw-ucrt
@@ -119,6 +120,7 @@ DEPENDENCIES
   jekyll-timeago
   logger
   moonwalk!
+  wdm (>= 0.1.0) x64-mingw-ucrt
 
 BUNDLED WITH
   4.0.9

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    wdm (0.2.0)
     webrick (1.9.1)
 
 PLATFORMS
@@ -120,7 +119,6 @@ DEPENDENCIES
   jekyll-timeago
   logger
   moonwalk!
-  wdm (>= 0.1.0)
 
 BUNDLED WITH
-   2.7.2
+  4.0.9


### PR DESCRIPTION
## Summary

- Regenerate `Gemfile.lock` on Linux so `wdm` (Windows-only file-watcher) is no longer listed without a platform qualifier — this was causing `bundle install` to fail in frozen/deployment mode on the CI runner
- Restore `wdm` to the lockfile with an explicit `x64-mingw-ucrt` platform qualifier so Windows local development continues to work without touching the lockfile

## Test plan

- [ ] Confirm the Actions workflow completes successfully (bundle install no longer fails)
- [ ] Confirm `bundle install` still works on Windows

https://claude.ai/code/session_01UeSdNPutYtkRsJbuDcaFmb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeSdNPutYtkRsJbuDcaFmb)_