### PR TITLE
Fix wdm platform handling for cross-platform builds

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'wdm', '>= 0.1.0', platforms: :windows
 gem 'csv'
 gem 'logger'
 gem 'base64'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -101,8 +101,8 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    webrick (1.9.1)
     wdm (0.2.0)
+    webrick (1.9.1)
 
 PLATFORMS
   x64-mingw-ucrt
@@ -120,7 +120,7 @@ DEPENDENCIES
   jekyll-timeago
   logger
   moonwalk!
-  wdm (>= 0.1.0) x64-mingw-ucrt
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
   4.0.9


### PR DESCRIPTION
## Summary

- Replace `gem 'wdm' if Gem.win_platform?` with `gem 'wdm', platforms: :windows` in the Gemfile

`if Gem.win_platform?` is a Ruby conditional — on Linux the line is never evaluated, so bundler has no idea `wdm` was ever supposed to exist and treats it as deleted in frozen/deployment mode, failing CI. Using bundler's own `platforms:` DSL means bundler tracks the constraint itself and correctly skips `wdm` on Linux without erroring.

## Test plan

- [ ] Confirm CI `bundle install` completes without the "dependencies were deleted" error
- [ ] Confirm `bundle install` still works on Windows

https://claude.ai/code/session_01UeSdNPutYtkRsJbuDcaFmb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeSdNPutYtkRsJbuDcaFmb)_